### PR TITLE
Note security considerations in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # Nu-discord-bot
 
-A Discord bot built with Serenity that runs Nushell commands in a sandboxed context.
+A Discord bot built with Serenity that runs Nushell commands in a custom context with limited privileges.
+
+## Security
+
+Even though the set of nushell commands made available to users of this bot is limited and excludes some of
+the most obvious ways to interact with the host's file system and network, this is not, by itself, a secure level
+of sandboxing. If you're going to use this bot on discord servers with untrusted users, you should run it inside
+something like a docker container.
 
 ## To use
 


### PR DESCRIPTION
This PR modifies the readme to clarify that the bot does not run commands inside a *secure* sandbox, and adds a suggestion to use something like docker.

This repo's readme currently says that the bot runs nu commands "in a sandboxed context". This may be understood to mean that it's safe to run this bot without an additional layer of sandboxing around it. However, the bot has commands allowlisted that expose significant amounts of information about the system it's running on, as well as commands whose safety seems fragile to me.

The worst offender is the `history` command. Using this, discord users on a server with the bot installed are able to read the full command history of the host's nu install (if it's using the plaintext history format), which can contain extremely sensitive information:
![image](https://github.com/user-attachments/assets/844487db-9ecd-4a22-947f-5c28eaff6980)

As well as probably not being worth the effort because this project is unmaintained, I do not think a stricter default allowlist of nu commands would be an alternative to this PR because (as far as I know) there is no explicit effort by the nushell project to ensure that *any* of its built-in commands can safely be allowed to be run by untrusted parties, so the risk of a non-obvious "sandbox escape" vulnerability through some set of allowed commands would always be high.